### PR TITLE
add xv6-d1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This list is a collection of tools, projects, images and resources conforming to
 - [RVBoards Debian](https://popolon.org/depots/RISC-V/D1/ovsienko/) - Debian distribution build by [RVBoards](https://rvboards.org/) originally for the [Allwinner Nezha](https://linux-sunxi.org/Allwinner_Nezha). The 6.1 version needs the OpenixCard tool to write the image to an SD card, see [Tools](#tools).
 - [Tina Linux](https://mangopi.cc/d1) - The first OS image specifically for the MangoPi MQ-Pro, distributed by MangoPi. The OpenixCard tool is needed to write the image to an SD card, see [Tools](#tools).
 - [Ubuntu](http://cdimage.ubuntu.com/ubuntu-server/jammy/daily-preinstalled/current/jammy-preinstalled-server-riscv64+nezha.img.xz) - Ubuntu image, compatible with the MangoPi MQ Pro
+- [xv6-d1](https://github.com/michaelengel/xv6-d1) Port of MIT's xv6 OS to the Nezha RISC-V board with Allwinner D1 SoC. 
 
 ## Tools
 


### PR DESCRIPTION
Hi! Thanks for collecting useful material about this cool board.
This PR adds the port of xv6 to D1. It should work on the mqpro since it uses the Alwinner D1.